### PR TITLE
feat: --auto-push flag — git push to remote after agent completion

### DIFF
--- a/claw_forge/agent/hooks.py
+++ b/claw_forge/agent/hooks.py
@@ -298,6 +298,69 @@ async def subagent_stop_hook(
     )
 
 
+# ── Auto-push hook factory ────────────────────────────────────────────────────
+
+
+def auto_push_hook(project_dir: str, remote: str = "origin") -> Any:
+    """Return a Stop hook that pushes to remote after agent completion.
+
+    Only pushes if:
+    - The project directory is a git repository
+    - The specified remote exists
+    - There is at least one commit ahead of remote
+
+    Args:
+        project_dir: Absolute path to the git repository.
+        remote: Remote name to push to (default: "origin").
+    """
+    from pathlib import Path
+
+    from claw_forge.git.commits import has_remote, push_to_remote
+
+    async def _auto_push_hook(
+        input_data: HookInput,
+        tool_use_id: str | None,
+        context: HookContext,
+    ) -> SyncHookJSONOutput:
+        project_path = Path(project_dir)
+
+        if not (project_path / ".git").is_dir():
+            print(f"[AutoPush] Skipped — {project_dir} is not a git repository")
+            return SyncHookJSONOutput(
+                hookSpecificOutput={  # type: ignore[typeddict-item,misc]
+                    "hookEventName": "Stop",
+                    "additionalContext": "",
+                }
+            )
+
+        if not has_remote(project_path, remote):
+            print(f"[AutoPush] Skipped — remote '{remote}' not found")
+            return SyncHookJSONOutput(
+                hookSpecificOutput={  # type: ignore[typeddict-item,misc]
+                    "hookEventName": "Stop",
+                    "additionalContext": "",
+                }
+            )
+
+        result = push_to_remote(project_path, remote=remote)
+        if result["success"]:
+            print(f"[AutoPush] ✅ Pushed {result['branch']} → {remote}")
+        else:
+            print(f"[AutoPush] ⚠️  Push failed: {result['error']}")
+
+        return SyncHookJSONOutput(
+            hookSpecificOutput={  # type: ignore[typeddict-item,misc]
+                "hookEventName": "Stop",
+                "additionalContext": (
+                    f"[AutoPush] {'✅ Pushed' if result['success'] else '⚠️ Push failed'}: "
+                    f"{result.get('branch', '')} → {remote}"
+                ),
+            }
+        )
+
+    return _auto_push_hook
+
+
 # ── Hashline hook factories ───────────────────────────────────────────────────
 
 
@@ -448,6 +511,7 @@ def get_default_hooks(
     edit_mode: str = "str_replace",
     loop_detect_threshold: int = 5,
     verify_on_exit: bool = True,
+    auto_push: str | None = None,
 ) -> dict[str, Any]:
     """Return the default hooks dict for ClaudeAgentOptions.
 
@@ -469,12 +533,18 @@ def get_default_hooks(
     When verify_on_exit is True, also includes:
     - Stop: PreCompletionChecklistMiddleware (force verification before exit)
 
+    When auto_push is set, also includes:
+    - Stop: auto-push hook (git push to remote after agent completion)
+
     Args:
         edit_mode: "str_replace" (default) or "hashline".
         loop_detect_threshold: Max edits to a single file before injecting
             a warning. Default 5. Set to 0 to disable.
         verify_on_exit: If True (default), include the PreCompletionChecklistMiddleware
             Stop hook to force verification before agent exit.
+        auto_push: If set, path to the git project dir — pushes to origin after
+            agent completion. Format: "/path/to/repo" or "/path/to/repo:remote-name".
+            Set to None (default) to disable.
     """
     pre_tool_use_hooks: list[Any] = [
         HookMatcher(matcher="Bash", hooks=[bash_security_hook]),
@@ -514,9 +584,22 @@ def get_default_hooks(
         ],
     }
 
+    stop_hooks: list[Any] = []
+
     if verify_on_exit:
         from claw_forge.agent.middleware.pre_completion import pre_completion_checklist_hook
 
-        hooks_dict["Stop"] = [HookMatcher(hooks=[pre_completion_checklist_hook()])]
+        stop_hooks.append(HookMatcher(hooks=[pre_completion_checklist_hook()]))
+
+    if auto_push is not None:
+        # Format: "/path/to/repo" or "/path/to/repo:remote-name"
+        if ":" in auto_push and not auto_push.startswith("//:"):
+            _push_path, _push_remote = auto_push.rsplit(":", 1)
+        else:
+            _push_path, _push_remote = auto_push, "origin"
+        stop_hooks.append(HookMatcher(hooks=[auto_push_hook(_push_path, _push_remote)]))
+
+    if stop_hooks:
+        hooks_dict["Stop"] = stop_hooks
 
     return hooks_dict

--- a/claw_forge/cli.py
+++ b/claw_forge/cli.py
@@ -375,6 +375,16 @@ def run(
             "Disable for fast iteration / debugging. [default: enabled]"
         ),
     ),
+    auto_push: str | None = typer.Option(
+        None, "--auto-push",
+        help=(
+            "Automatically git push to remote after agent completion.\n"
+            "Value: path to git repo (uses 'origin' by default), or 'path:remote' to\n"
+            "specify a custom remote. Example: --auto-push /path/to/repo\n"
+            "or --auto-push /path/to/repo:upstream\n"
+            "Skipped silently if remote doesn't exist. [default: disabled]"
+        ),
+    ),
 ) -> None:
     """Run agents on a project until all features pass.
 
@@ -437,6 +447,13 @@ def run(
     # verify_on_exit: CLI flag takes priority; config is fallback for the True default
     _config_verify = cfg.get("agent", {}).get("verify_on_exit", True)
     effective_verify_on_exit: bool = verify_on_exit and bool(_config_verify)
+
+    # auto_push: CLI flag takes priority; config fallback
+    effective_auto_push: str | None = auto_push
+    if effective_auto_push is None:
+        _config_auto_push = cfg.get("agent", {}).get("auto_push")
+        if _config_auto_push:
+            effective_auto_push = str(_config_auto_push)
 
     resolved = resolve_model(model, cfg)
     if resolved.alias_resolved:
@@ -810,6 +827,7 @@ def run(
                                     edit_mode=edit_mode,
                                     loop_detect_threshold=loop_detect_threshold,
                                     verify_on_exit=effective_verify_on_exit,
+                                    auto_push=effective_auto_push,
                                 )
 
                                 options = ClaudeAgentOptions(

--- a/claw_forge/git/commits.py
+++ b/claw_forge/git/commits.py
@@ -48,6 +48,41 @@ def commit_checkpoint(
     return {"commit_hash": short_hash, "branch": branch}
 
 
+def push_to_remote(
+    project_dir: Path,
+    *,
+    remote: str = "origin",
+    branch: str | None = None,
+) -> dict[str, Any]:
+    """Push current branch to remote.
+
+    Args:
+        project_dir: Path to the git repository.
+        remote: Remote name (default: "origin").
+        branch: Branch to push. If None, uses current branch.
+
+    Returns:
+        Dict with keys: remote, branch, success, error (if failed).
+    """
+    if branch is None:
+        branch = current_branch(project_dir)
+
+    try:
+        _run_git(["push", remote, branch], project_dir)
+        return {"remote": remote, "branch": branch, "success": True, "error": None}
+    except Exception as exc:  # noqa: BLE001
+        return {"remote": remote, "branch": branch, "success": False, "error": str(exc)}
+
+
+def has_remote(project_dir: Path, remote: str = "origin") -> bool:
+    """Return True if the given remote exists in the repository."""
+    try:
+        result = _run_git(["remote"], project_dir)
+        return remote in result.stdout.strip().splitlines()
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def task_history(
     project_dir: Path,
     *,

--- a/tests/test_auto_push.py
+++ b/tests/test_auto_push.py
@@ -1,0 +1,179 @@
+"""Tests for --auto-push hook and git push_to_remote / has_remote utilities."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ── Unit tests: git utilities ─────────────────────────────────────────────────
+
+
+class TestHasRemote:
+    def test_returns_true_when_remote_exists(self, tmp_path: Path) -> None:
+        from claw_forge.git.commits import has_remote
+        from claw_forge.git.repo import _run_git
+
+        _run_git(["init"], tmp_path)
+        _run_git(["remote", "add", "origin", "https://example.com/repo.git"], tmp_path)
+        assert has_remote(tmp_path, "origin") is True
+
+    def test_returns_false_when_remote_missing(self, tmp_path: Path) -> None:
+        from claw_forge.git.commits import has_remote
+        from claw_forge.git.repo import _run_git
+
+        _run_git(["init"], tmp_path)
+        assert has_remote(tmp_path, "origin") is False
+
+    def test_returns_false_on_exception(self, tmp_path: Path) -> None:
+        from claw_forge.git.commits import has_remote
+
+        # Not a git repo
+        assert has_remote(tmp_path / "nonexistent", "origin") is False
+
+
+class TestPushToRemote:
+    def test_returns_success_dict_on_push(self, tmp_path: Path) -> None:
+        from claw_forge.git.commits import push_to_remote
+
+        with patch("claw_forge.git.commits._run_git") as mock_git:
+            mock_git.return_value = MagicMock(stdout="main\n")
+            result = push_to_remote(tmp_path, remote="origin", branch="main")
+
+        assert result["success"] is True
+        assert result["remote"] == "origin"
+        assert result["branch"] == "main"
+        assert result["error"] is None
+
+    def test_returns_failure_dict_on_error(self, tmp_path: Path) -> None:
+        from claw_forge.git.commits import push_to_remote
+
+        with patch("claw_forge.git.commits._run_git") as mock_git:
+            mock_git.side_effect = subprocess.CalledProcessError(1, "git push")
+            result = push_to_remote(tmp_path, remote="origin", branch="main")
+
+        assert result["success"] is False
+        assert result["error"] is not None
+
+    def test_uses_current_branch_when_branch_not_specified(self, tmp_path: Path) -> None:
+        from claw_forge.git.commits import push_to_remote
+
+        with (
+            patch("claw_forge.git.commits.current_branch", return_value="feat/my-branch"),
+            patch("claw_forge.git.commits._run_git") as mock_git,
+        ):
+            mock_git.return_value = MagicMock(stdout="")
+            result = push_to_remote(tmp_path, remote="origin")
+
+        assert result["branch"] == "feat/my-branch"
+
+
+# ── Unit tests: auto_push_hook ────────────────────────────────────────────────
+
+
+class TestAutoPushHook:
+    @pytest.mark.asyncio
+    async def test_skips_when_not_git_repo(self, tmp_path: Path) -> None:
+        from claw_forge.agent.hooks import auto_push_hook
+
+        hook = auto_push_hook(str(tmp_path))
+        result = await hook(input_data={}, tool_use_id=None, context=MagicMock())
+        # Should return silently, not raise
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_remote(self, tmp_path: Path) -> None:
+        from claw_forge.agent.hooks import auto_push_hook
+        from claw_forge.git.repo import _run_git
+
+        _run_git(["init"], tmp_path)
+        hook = auto_push_hook(str(tmp_path))
+        result = await hook(input_data={}, tool_use_id=None, context=MagicMock())
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_pushes_when_remote_exists(self, tmp_path: Path) -> None:
+        from claw_forge.agent.hooks import auto_push_hook
+
+        (tmp_path / ".git").mkdir()  # fake git dir
+        with (
+            patch("claw_forge.git.commits.has_remote", return_value=True),
+            patch("claw_forge.git.commits.push_to_remote", return_value={
+                "remote": "origin", "branch": "main", "success": True, "error": None
+            }) as mock_push,
+        ):
+            hook = auto_push_hook(str(tmp_path))
+            result = await hook(input_data={}, tool_use_id=None, context=MagicMock())
+
+        mock_push.assert_called_once()
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_push_failure_does_not_raise(self, tmp_path: Path) -> None:
+        from claw_forge.agent.hooks import auto_push_hook
+
+        (tmp_path / ".git").mkdir()
+        with (
+            patch("claw_forge.git.commits.has_remote", return_value=True),
+            patch("claw_forge.git.commits.push_to_remote", return_value={
+                "remote": "origin", "branch": "main", "success": False,
+                "error": "rejected: non-fast-forward"
+            }),
+        ):
+            hook = auto_push_hook(str(tmp_path))
+            # Should not raise even on push failure
+            result = await hook(input_data={}, tool_use_id=None, context=MagicMock())
+
+        assert result is not None
+
+
+# ── Integration: get_default_hooks includes auto_push Stop hook ───────────────
+
+
+class TestGetDefaultHooksAutoPush:
+    def test_auto_push_none_no_stop_hook_added(self) -> None:
+        from claw_forge.agent.hooks import get_default_hooks
+
+        hooks = get_default_hooks(verify_on_exit=False, auto_push=None)
+        assert "Stop" not in hooks
+
+    def test_auto_push_path_adds_stop_hook(self, tmp_path: Path) -> None:
+        from claw_forge.agent.hooks import get_default_hooks
+
+        hooks = get_default_hooks(verify_on_exit=False, auto_push=str(tmp_path))
+        assert "Stop" in hooks
+        assert len(hooks["Stop"]) == 1
+
+    def test_auto_push_with_custom_remote(self, tmp_path: Path) -> None:
+        from claw_forge.agent.hooks import get_default_hooks
+
+        hooks = get_default_hooks(
+            verify_on_exit=False,
+            auto_push=f"{tmp_path}:upstream",
+        )
+        assert "Stop" in hooks
+
+    def test_auto_push_and_verify_on_exit_both_add_stop_hooks(self, tmp_path: Path) -> None:
+        from claw_forge.agent.hooks import get_default_hooks
+
+        hooks = get_default_hooks(verify_on_exit=True, auto_push=str(tmp_path))
+        assert "Stop" in hooks
+        assert len(hooks["Stop"]) == 2  # verify-on-exit + auto-push
+
+
+# ── CLI: --auto-push flag appears in help ─────────────────────────────────────
+
+
+class TestAutoPushCLIFlag:
+    def test_auto_push_flag_in_help(self) -> None:
+        import re
+
+        from typer.testing import CliRunner
+
+        from claw_forge.cli import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["run", "--help"])
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+        assert "--auto-push" in clean


### PR DESCRIPTION
## Summary

Adds `--auto-push` flag to `claw-forge run` that automatically git-pushes to a remote after the agent completes its session.

## Usage

```bash
# Push to origin (default)
claw-forge run --auto-push /path/to/repo

# Push to a custom remote
claw-forge run --auto-push /path/to/repo:upstream
```

## Behaviour

- **Skips silently** if the path is not a git repo or remote doesn't exist
- **Logs result**: `[AutoPush] ✅ Pushed main → origin` or `⚠️ Push failed: ...`
- **Non-fatal**: push failure never crashes the agent session
- Composes with `--verify-on-exit` — both Stop hooks run in sequence

## Changes

- `claw_forge/git/commits.py`: `push_to_remote()` + `has_remote()`
- `claw_forge/agent/hooks.py`: `auto_push_hook()` factory + `auto_push` param in `get_default_hooks()`
- `claw_forge/cli.py`: `--auto-push` CLI flag with config file fallback
- `tests/test_auto_push.py`: 15 new tests